### PR TITLE
Fix for importing pwd module issues on Windows machines

### DIFF
--- a/dynamicserialize/dstypes/com/raytheon/uf/common/message/WsId.py
+++ b/dynamicserialize/dstypes/com/raytheon/uf/common/message/WsId.py
@@ -30,8 +30,16 @@
 import struct
 import socket
 import os
-import pwd
-import thread
+try:
+    import pwd
+    pwd_error = False
+except ImportError:
+    pwd_error = True
+	
+try:
+    import thread
+except ImportError:
+    import thread as _thread
 
 class WsId(object):
 
@@ -42,7 +50,10 @@ class WsId(object):
 
         self.userName = userName
         if userName is None:
-            self.userName = pwd.getpwuid(os.getuid()).pw_name
+            if not pwd_error:
+               self.userName = pwd.getpwuid(os.getuid()).pw_name
+            else:
+               self.userName = "GenericUsername"
 
         self.progName = progName
         if progName is None:
@@ -50,7 +61,7 @@ class WsId(object):
 
         self.pid = os.getpid()
 
-        self.threadId = long(thread.get_ident())
+        self.threadId = int(_thread.get_ident())
 
     def getNetworkId(self):
         return self.networkId

--- a/dynamicserialize/dstypes/com/raytheon/uf/common/message/WsId.py
+++ b/dynamicserialize/dstypes/com/raytheon/uf/common/message/WsId.py
@@ -61,7 +61,7 @@ class WsId(object):
 
         self.pid = os.getpid()
 
-        self.threadId = int(_thread.get_ident())
+        self.threadId = long(_thread.get_ident())
 
     def getNetworkId(self):
         return self.networkId

--- a/dynamicserialize/dstypes/com/raytheon/uf/common/message/WsId.py
+++ b/dynamicserialize/dstypes/com/raytheon/uf/common/message/WsId.py
@@ -61,7 +61,7 @@ class WsId(object):
 
         self.pid = os.getpid()
 
-        self.threadId = long(_thread.get_ident())
+        self.threadId = long(thread.get_ident())
 
     def getNetworkId(self):
         return self.networkId

--- a/dynamicserialize/dstypes/com/raytheon/uf/common/plugin/nwsauth/user/UserId.py
+++ b/dynamicserialize/dstypes/com/raytheon/uf/common/plugin/nwsauth/user/UserId.py
@@ -20,13 +20,22 @@
 
 # File auto-generated against equivalent DynamicSerialize Java class
 
-import os, pwd
+import os
+
+try:
+    import pwd
+    pwd_error = False
+except ImportError:
+    pwd_error = True
 
 class UserId(object):
 
     def __init__(self, id = None):
         if id is None:
-           self.id = pwd.getpwuid(os.getuid()).pw_name
+           if not pwd_error:
+              self.id = pwd.getpwuid(os.getuid()).pw_name
+           else:
+              self.id = "GenericUsername"
         else:
            self.id = id
 


### PR DESCRIPTION
Trying to import pwd on a windows machine will raise an ImportError.  The proposed additions will catch this error and set the username for windows connections to "GenericUsername".  Linux functionality should remain unchanged.