### PR TITLE
MNT: Fix import on Python 2

### DIFF
--- a/awips/stomp.py
+++ b/awips/stomp.py
@@ -63,6 +63,7 @@
     * 2009/04/02 : (Fernando Ciciliati) fix overflow bug when waiting too long to connect to the broker
 
 """
+from __future__ import print_function
 
 import hashlib
 import math


### PR DESCRIPTION
Was missing __future__ import to get print as a function.