### PR TITLE
Fix bytestring/string incompatability when error backtrace is generated

### DIFF
--- a/dynamicserialize/dstypes/com/raytheon/uf/common/serialization/SerializableExceptionWrapper.py
+++ b/dynamicserialize/dstypes/com/raytheon/uf/common/serialization/SerializableExceptionWrapper.py
@@ -24,6 +24,7 @@ class SerializableExceptionWrapper(object):
         if not self.message:
             self.message = b''
         retVal = b"" + self.exceptionClass + b" exception thrown: " + self.message + b"\n"
+        retVal = retVal.decode('UTF-8')
         for element in self.stackTrace:
             retVal += "\tat " + str(element) + "\n"
 


### PR DESCRIPTION
In Python 3, the following example program, which has an intentional typo:
```
from awips.dataaccess import DataAccessLayer

DataAccessLayer.changeEDEXHost('edex-cloud.unidata.ucar.edu')

request = DataAccessLayer.newDataRequest()
request.setDatatype('grid')
request.setLocationNames('RAP13')
request.setParameters('T')
request.setLevels('2.OFHAG')

cycles = DataAccessLayer.getAvailableTimes(request, True)
```
generates this error:
```
Traceback (most recent call last):
  File "weatherdataex3.py", line 11, in <module>
    cycles = DataAccessLayer.getAvailableTimes(request, True)
  File "/home/decker/src/python-awips/awips/dataaccess/DataAccessLayer.py", line 71, in getAvailableTimes
    return router.getAvailableTimes(request, refTimeOnly)
  File "/home/decker/src/python-awips/awips/dataaccess/ThriftClientRouter.py", line 57, in getAvailableTimes
    response = self._client.sendRequest(timesRequest)
  File "/home/decker/src/python-awips/awips/ThriftClient.py", line 72, in sendRequest
    raise ThriftRequestException(forceError)
awips.ThriftClient.ThriftRequestException: <exception str() failed>
```
Instead, it should produce a very long backtrace as it does when run under Python 2. This PR fixes this, so that the code when run under Python 3 behaves the same as under Python 2. The backtrace that appears under Python 2 does make it slightly more obvious where the typo is. 

