### PR TITLE
Website generation fails for html within markdown cells

### DIFF
--- a/examples/notebooks/Grid_Levels_and_Parameters.ipynb
+++ b/examples/notebooks/Grid_Levels_and_Parameters.ipynb
@@ -640,9 +640,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-warning\">\n",
-    "<b>Warning:</b>  Not all datasets support levels.  If you are trying this with another dataset and run into an exception (error), it's most likely because levels are not supported for that data type.\n",
-    "</div> "
+    "> **Warning**: Not all datasets support levels.  If you are trying this with another dataset and run into an exception (error), it's most likely because levels are not supported for that data type."
    ]
   },
   {
@@ -1061,9 +1059,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-info\">\n",
-    "<b>Note:</b> We have more, detailed notebooks about how analyze and visualize the data once you have what you want.\n",
-    "</div>"
+    "> **Note**: We have more, detailed notebooks about how analyze and visualize the data once you have what you want."
    ]
   },
   {
@@ -1150,7 +1146,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/Grids_and_Cartopy.ipynb
+++ b/examples/notebooks/Grids_and_Cartopy.ipynb
@@ -136,9 +136,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-info\">\n",
-    "<b>Note:</b> You can play around with different times and forecast runs to see the differences.\n",
-    "</div>"
+    "> **Note**: You can play around with different times and forecast runs to see the differences."
    ]
   },
   {
@@ -250,9 +248,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert-info\">\n",
-    "<b>Note:</b>  You may see a warning appear with a red background, this is okay, and will go away with subsequent runs of the cell.\n",
-    "</div>"
+    "> **Note**: You may see a warning appear with a red background, this is okay, and will go away with subsequent runs of the cell."
    ]
   },
   {
@@ -388,7 +384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/Map_Resources_and_Topography.ipynb
+++ b/examples/notebooks/Map_Resources_and_Topography.ipynb
@@ -153,11 +153,9 @@
     "\n",
     "* Each map database table has a geometry field called `the_geom`, which can be used to spatially select map resources for any column of type geometry.\n",
     "\n",
-    "<br>\n",
-    "<div class=\"alert-info\">\n",
-    "    <b>Tip:</b>  Note the geometry definition of <code>the_geom</code> for each data type, which can be <b>Point</b>, <b>MultiPolygon</b>, or <b>MultiLineString</b>.\n",
-    "</div>\n",
-    "<br>\n",
+    "\n",
+    "> **Tip**: Note the geometry definition of `the_geom` for each data type, which can be **Point**, **MultiPolygon**, or **MultiLineString**.\n",
+    "\n",
     "\n",
     "Here we'll be using Boulder (BOU) as our example for plotting the County Warning Area (CWA).  We'll query our EDEX server to get all counties in the CWA for BOU, and then plot those counties along withe the state boundaries and lines of longitude and latitude.  In order to get this information from EDEX, we'll need to set several characteristics on our data request object.  We will use [**request.setParameters()**](http://unidata.github.io/python-awips/api/IDataRequest.html#awips.dataaccess.IDataRequest.setParameters) to refine our query to EDEX."
    ]
@@ -366,10 +364,7 @@
     "\n",
     "Request the city table based using the **envelope** attribute and filter by population and progressive disclosure level.\n",
     "\n",
-    "<br>\n",
-    "<div class=\"alert-warning\">\n",
-    "    <b>Warning:</b>  the <code>prog_disc</code> field is not entirely understood and values appear to change significantly depending on WFO site.\n",
-    "</div>"
+    "> **Warning**: The `prog_disc` field is not entirely understood and values appear to change significantly depending on WFO site."
    ]
   },
   {
@@ -673,7 +668,7 @@
     "        request.setLocationNames('BOU')\n",
     "        request.addIdentifier('cwa', 'BOU')\n",
     "        \n",
-    "See the <a href=\"http://unidata.github.io/awips2/python/maps-database/#mapdatacwa\">Maps Database Reference Page</a> for available database tables, column names, and types. "
+    "See the [Maps Database Reference Page](http://unidata.github.io/awips2/python/maps-database/#mapdatacw) for available database tables, column names, and types. "
    ]
   },
   {


### PR DESCRIPTION
- update "note", "tip", "warning" blocks to use ">" blocks (which is what the old notebooks used)
- updatea an html link for the Map Resources and Topo in the Additional Documentation to use markdown syntax so it renders properly in the generated webpage