### PR TITLE
Small change to environment.yml for compatibility with notebooks

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@
  channels:
    - https://conda.anaconda.org/conda-forge
  dependencies:
-   - python=3
+   - python=3.9
    - numpy
    - nomkl
    - matplotlib


### PR DESCRIPTION
- updated the python requirment from '=3' to '=3.9' because at least one notebook (METARS) was failing with python 3.10