### PR TITLE
Changes to make python-awips compatible with Python3.10

### DIFF
--- a/dynamicserialize/dstypes/java/util/EnumSet.py
+++ b/dynamicserialize/dstypes/java/util/EnumSet.py
@@ -17,10 +17,10 @@
 # values to your EnumSet.
 ##
 
-import collections
+import collections.abc
 
 
-class EnumSet(collections.MutableSet):
+class EnumSet(collections.abc.MutableSet):
 
     def __init__(self, enumClassName, iterable=[]):
         self.__enumClassName = enumClassName

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@
  channels:
    - https://conda.anaconda.org/conda-forge
  dependencies:
-   - python=3.9
+   - python=3
    - numpy
    - nomkl
    - matplotlib

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ dependencies = ['numpy', 'six']
 if sys.version_info < (3, 4):
     dependencies.append('enum34')
 
-ver = "18.1.10"
+ver = "18.1.11"
 
 setup(
     name='python-awips',

--- a/thrift/server/TProcessPoolServer.py
+++ b/thrift/server/TProcessPoolServer.py
@@ -23,7 +23,7 @@ from multiprocessing import  Process, Value, Condition, reduction
 
 from .TServer import TServer
 from thrift.transport.TTransport import TTransportException
-import collections
+import collections.abc
 
 
 class TProcessPoolServer(TServer):
@@ -41,7 +41,7 @@ class TProcessPoolServer(TServer):
         self.postForkCallback = None
 
     def setPostForkCallback(self, callback):
-        if not isinstance(callback, collections.Callable):
+        if not isinstance(callback, collections.abc.Callable):
             raise TypeError("This is not a callback!")
         self.postForkCallback = callback
 


### PR DESCRIPTION
- change collections import to collections.abc
- change specific class reference from collections.[class_name] to collections.abc.[class_name]
- change environment file back to specifying Python3, instead of exactly specifying 3.9
- roll version number in setup.py