### PR TITLE
Update release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  # Update GitHub Actions versions in workflows
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: all
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    commit-message:
+      prefix: "CI: "
+      include: "scope"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
     environment:
       name: PyPI
       url: https://pypi.org/project/python-awips/
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     runs-on: ubuntu-latest
     steps:
     - name: Download packages
@@ -47,7 +49,4 @@ jobs:
         name: artifact
 
     - name: Publish Package
-      uses: pypa/gh-action-pypi-publish@v1.4.2
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@v1.12.4


### PR DESCRIPTION
* Updated the versions of various actions in the workflow
* Added a dependabot config that should automatically send in PRs for updates to these actions
* Switch to use PyPI ["trusted publisher"](https://docs.pypi.org/trusted-publishers/) (see below)

PyPI's new trusted publisher support allows configuring, on the PyPI project, a specific GitHub Actions workflow and (optionally environment--like your "pypi" environment) that is permitted to publish to PyPI. Using existing publication action you're using from PyPA, GitHub and PyPI will automatically exchange the needed (short-lived) tokens to permit the publication. This eliminates having a persistent, shared secret that is associated with a particular user account, and instead everything uses short-lived tokens and configuration that is done at the project infrastructure level.

If you're happy proceeding this way, the additional steps with this PR are:
* [x] Remove the `PYPI_TOKEN` from [the PyPI environment](https://github.com/Unidata/python-awips/settings/environments/368879868/edit)
* [x] Delete the token from the user account
* [x] Configure the [python-awips pypi project](https://pypi.org/manage/project/python-awips/settings/publishing/) to trust the `release.yml` workflow