### PR TITLE
Small change from MJ for getEnumSet

### DIFF
--- a/dynamicserialize/adapters/EnumSetAdapter.py
+++ b/dynamicserialize/adapters/EnumSetAdapter.py
@@ -29,7 +29,7 @@
 #    ------------    ----------    -----------    --------------------------
 #    07/28/11                      dgilling       Initial Creation.
 #    12/02/13        2537          bsteffen       Serialize empty enum sets.
-#    
+#    09/11/23                      srcarter@ucar  MJ change for set has no attribute getEnumClass
 # 
 #
 
@@ -43,7 +43,7 @@ ClassAdapter = ['java.util.EnumSet', 'java.util.RegularEnumSet']
 def serialize(context, set):
     setSize = len(set)
     context.writeI32(setSize)
-    context.writeString(set.getEnumClass())
+    context.writeString(bufferset.getEnumClass())
     for val in set:
         context.writeString(val)
     


### PR DESCRIPTION
- set has no attribute getEnumSet, use bufferset
- see [this previous MJ commit](https://github.com/Unidata/python-awips/commit/e20bf91a32b9f2e497c7faaa580679f2f8c92624)