### PR TITLE
Environment changes for v20 branch

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
- name: python3-awips
+ name: python-awips-beta20
  channels:
    - https://conda.anaconda.org/conda-forge
  dependencies:
@@ -24,5 +24,4 @@
    - six
    - pip
    - jupyter_contrib_nbextensions
-   - python-awips
    


### PR DESCRIPTION
- change the name of the environment to `python-awips-beta20`
- remove the python-awips package from the environment, because it needs to be installed from the local source code