### PR TITLE
Minor update to notebook_test github action

### DIFF
--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -36,6 +36,6 @@ jobs:
         shell: micromamba-shell {0}
         run: |
           pytest \
-            --nbmake examples/notebooks/*.ipynb \
+            --nbmake examples/notebooks \
             --ignore=examples/notebooks/GOES_CIRA_Product_Writer.ipynb \
             --nbmake-timeout=600


### PR DESCRIPTION
Had to remove the *ipynb because it was still including the GOES CIRA notebook which we are wanting to ignore