### PR TITLE
Updated prep.sh script so it re-creates the src code

### DIFF
--- a/prep.sh
+++ b/prep.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 # python-awips prep script
 # author: mjames@ucar.edu
-#
+# author: tiffanym@ucar.edu
+
+# This script scrapes the awips2 repos for dynamicserialize, thrift, and awips to package them for python-awips
 
 # should be /awips2/repo/python-awips or ~/python-awips
 dir="$( cd "$(dirname "$0")" ; pwd -P )"
+echo $dir
+rm -rf ${dir}/src
 
 # Find plugin-contributed files and add them to the site packages.
+mkdir -p ${dir}/src/dynamicserialize
+
 find /awips2/repo/awips2-core/common/ -path '*/pythonPackages/dynamicserialize' \
-   -exec cp {} -rv ${dir} \;
-find /awips2/repo/awips2-builds/edexOsgi/ -path '*/pythonPackages/dynamicserialize' \
-   -exec cp {} -rv ${dir} \;
+   -exec cp {} -rv ${dir}/src \;
+find /awips2/repo/awips2-hazards/common/ -path '*/pythonPackages/dynamicserialize' \
+   -exec cp {} -rv ${dir}/src \;
+find /awips2/repo/awips2/ -path '*/pythonPackages/dynamicserialize' \
+   -exec cp {} -rv ${dir}/src \;
 
 #bash %{_baseline_workspace}/build.edex/opt/tools/update_dstypes.sh %{_build_root}/awips2/python/lib/python2.7/site-packages/dynamicserialize
 
@@ -20,7 +28,7 @@ find /awips2/repo/awips2-builds/edexOsgi/ -path '*/pythonPackages/dynamicseriali
 
 echo "Updating dynamicserialize/dstypes"
 # Update __all__  for every package under dstypes
-for package in $(find dynamicserialize/dstypes -name __init__.py -printf '%h ')
+for package in $(find src/dynamicserialize/dstypes -name __init__.py -printf '%h ')
 do
     pushd $package > /dev/null
     # find non-hidden packages
@@ -39,15 +47,50 @@ do
 
     popd > /dev/null
 done
+
 echo "Done"
 
-#find ${dir} -type f | xargs sed -i 's/[ \t]*$//'
-git grep -l 'ufpy' | xargs sed -i 's/ufpy/awips/g'
+#################
+# Updating ufpy
+#################
+mkdir -p ${dir}/src/awips
+cp -r /awips2/repo/awips2/pythonPackages/ufpy/* ${dir}/src/awips/
 
-#find ${dir} -type f | xargs sed -i '/# This software was developed and \/ or modified by Raytheon Company,/,/# further licensing information./d'
+# Replace all instances of ufpy with awips
+rg -l -0 'ufpy' -- src/ | xargs -0 sed -i 's/ufpy/awips/g'
+###################
+# Updating thrift  
+###################
+mkdir -p ${dir}/src/thrift
+
+find /awips2/repo/awips2-core/ -path '*/bin/*/serialization/thrift' \
+   -exec cp {} -rv ${dir}/src \;
 
 
+find /awips2/repo/awips2-rpm -name 'thrift*gz' \
+    -exec tar -xzf {} \
+    -C "${dir}/src/thrift/" \
+    --strip-components=4 \
+    thrift-0.18.1/lib/py/src/ \;
 
-# update import strings for python3 compliance
+rm -rf ${dir}/src/thrift/ext
 
+# These are files that are Unidata specific and need to be restored
+git restore ${dir}/src/awips/RadarCommon.py
+git restore ${dir}/src/awips/dataaccess/ModelSounding.py
+git restore ${dir}/src/awips/tables.py
+git restore ${dir}/src/dynamicserialize/dstypes/com/raytheon/uf/common/datastorage/records/AbstractDataRecord.py
 
+# These are files that Unidata made changes to and most likely we will want to keep our changes - most likely none of these files have changed by NWS
+git restore ${dir}/src/awips/dataaccess/DataAccessLayer.py
+git restore ${dir}/src/awips/dataaccess/ThriftClientRouter.py
+git restore ${dir}/src/awips/gfe/IFPClient.py
+git restore ${dir}/src/dynamicserialize/dstypes/com/raytheon/uf/common/auth/user/UserId.py
+git restore ${dir}/src/dynamicserialize/dstypes/com/raytheon/uf/common/dataplugin/gfe/db/objects/GFERecord.py
+git restore ${dir}/src/dynamicserialize/dstypes/com/raytheon/uf/common/dataplugin/gfe/db/objects/ParmID.py
+git restore ${dir}/src/dynamicserialize/dstypes/com/raytheon/uf/common/dataplugin/level/Level.py
+git restore ${dir}/src/dynamicserialize/dstypes/com/raytheon/uf/common/dataquery/requests/RequestConstraint.py
+git restore ${dir}/src/dynamicserialize/dstypes/com/raytheon/uf/common/dataplugin/level/MasterLevel.py
+git restore ${dir}/src/dynamicserialize/dstypes/com/raytheon/uf/common/localization/LocalizationLevel.py
+git restore ${dir}/src/dynamicserialize/dstypes/com/raytheon/uf/common/message/WsId.py
+git restore ${dir}/src/dynamicserialize/dstypes/java/util/EnumSet.py

--- a/rpm/component.spec
+++ b/rpm/component.spec
@@ -25,7 +25,7 @@ Requires: awips2-python-six
 Requires: awips2-python-shapely
 Provides: awips2-python-awips = %{version}
 
-Obsoletes: awips2-python-ufpy < 15.1.3-1
+Obsoletes: awips2-python-awips < 15.1.3-1
 Obsoletes: awips2-python-dynamicserialize < 15.1.3-1
 Obsoletes: awips2-python-thrift < 20080411p1-4
 


### PR DESCRIPTION
This script scrapes the awips2 repos for the following directories:
- dynamicserialize
- thrift
- ufpy -> awips

It also grabs the thrift python files from awips2-rpm It restores Unidata only files
It restores Unidata changed files